### PR TITLE
Centos 7 install code-deploy as rpm and require ruby.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,14 @@ class codedeploy::install {
     'RedHat', 'Amazon': {
       package { $::codedeploy::package_name:
         ensure => present,
+        provider => 'rpm',
         source => $::codedeploy::package_url,
+        require => Package['ruby'],
+      }
+      if ! defined(Package['ruby']) {
+        package { 'ruby':
+          ensure => present,
+        }
       }
     }
     'Debian': {


### PR DESCRIPTION
I have tested against Centos 7. I don't think it will work with Centos 6 because there isn't a package available for Ruby 2.0