### PR TITLE
Uses wget to download the codedeploy install script

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,7 +28,7 @@ class codedeploy::install {
         }
       }
       exec { 'download_codedeploy_installer':
-        command => '/usr/bin/aws s3 cp s3://aws-codedeploy-us-east-1/latest/install . --region us-east-1',
+        command => '/usr/bin/wget --quiet --timestamping https://s3.amazonaws.com/aws-codedeploy-us-east-1/latest/install',
         cwd     => '/tmp',
         creates => '/tmp/install'
       }


### PR DESCRIPTION
Using wget to download the codedeploy install script is much easier (no need for setting up aws access keys for using `aws s3 cp`).
