### PR TITLE
Add ordering relationship between package['awscli'] and exec['download_codedeploy_installer']

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,6 +28,7 @@ class codedeploy::install {
         command => '/usr/bin/aws s3 cp s3://aws-codedeploy-us-east-1/latest/install . --region us-east-1',
         cwd     => '/tmp',
         creates => '/tmp/install',
+        require => Package['awscli'],
       }
       file { '/tmp/install':
         ensure    => file,


### PR DESCRIPTION
This might fail with the following error, if you apply your module with random ordering.

```
Error: Could not find command '/usr/bin/aws'
Error: /Stage[main]/Codedeploy::Install/Exec[download_codedeploy_installer]/returns: change from notrun to 0 failed: Could not find command '/usr/bin/aws'
```

This pull request adds ordering relationship between `Package['awscli']` and `Exec['download_codedeploy_installer']`.